### PR TITLE
Add ability to stop MockServer again

### DIFF
--- a/lib/mock_server.rb
+++ b/lib/mock_server.rb
@@ -23,6 +23,14 @@ class MockServer
     self
   end
 
+  def stop
+    Rack::Handler::WEBrick.shutdown
+
+    wait_for_shutdown("0.0.0.0", @port)
+
+    self
+  end
+
   module Methods
     def mock_server(*args, &block)
       app = Class.new(Sinatra::Base)
@@ -45,6 +53,7 @@ protected
       socket.close unless socket.nil?
       true
     rescue Errno::ECONNREFUSED,
+      Errno::ECONNRESET,
       Errno::EBADF,           # Windows
       Errno::EADDRNOTAVAIL    # Windows
       false
@@ -57,6 +66,18 @@ protected
     until listening?(host, port)
       if timeout && (Time.now > (start_time + timeout))
         raise SocketError.new("Socket did not open within #{timeout} seconds")
+      end
+    end
+
+    true
+  end
+
+  def wait_for_shutdown(host, port, timeout = 5)
+    start_time = Time.now
+
+    until !listening?(host, port)
+      if timeout && (Time.now > (start_time + timeout))
+        raise SocketError.new("Socket did not close within #{timeout} seconds")
       end
     end
 

--- a/test/mock_server_test.rb
+++ b/test/mock_server_test.rb
@@ -50,3 +50,20 @@ class MockServerMethodsTest < Test::Unit::TestCase
     assert_equal "Goodbye", open("http://localhost:4002").read
   end
 end
+
+class MockServerStopTest < Test::Unit::TestCase
+  def setup
+    @server = MockServer.new(HelloWorldSinatra, 4003)
+    @server.start
+  end
+
+  def test_stop_server
+    assert_equal "Hello", open("http://localhost:4003").read
+
+    @server.stop
+
+    assert_raises(Errno::ECONNREFUSED) {
+      open("http://localhost:4003").read
+    }
+  end
+end


### PR DESCRIPTION
This is useful when using MockServer in different test files
and you are running the full suite.
