### PR TITLE
Add ability to specify host

### DIFF
--- a/test/mock_server_test.rb
+++ b/test/mock_server_test.rb
@@ -29,7 +29,7 @@ end
 
 class MockServerRackBuilderTest < Test::Unit::TestCase
   def setup
-    @server = MockServer.new(HelloWorldRackBuilder, 4001)
+    @server = MockServer.new(HelloWorldRackBuilder, port: 4001)
     @server.start
   end
 
@@ -40,7 +40,7 @@ class MockServerRackBuilderTest < Test::Unit::TestCase
 class MockServerMethodsTest < Test::Unit::TestCase
   extend MockServer::Methods
 
-  mock_server(4002) {
+  mock_server(port: 4002) {
     get "/" do
       "Goodbye"
     end


### PR DESCRIPTION
Newer Debian and others might use e.g. `127.0.1.1` for localhost, and so
we need the ability to specify it manualle. Change to Ruby 2 keyword
arguments as well.
